### PR TITLE
Implement the SuperVectorizer and dirty_cat's encoders to the search space

### DIFF
--- a/gama/configuration/classification.py
+++ b/gama/configuration/classification.py
@@ -27,18 +27,7 @@ from sklearn.feature_selection import (
     VarianceThreshold,
 )
 
-from dirty_cat import (
-    SuperVectorizer,
-    SimilarityEncoder,
-    GapEncoder,
-    MinHashEncoder,
-)
-from sklearn.preprocessing import (
-    OneHotEncoder,
-    OrdinalEncoder,
-    StandardScaler,
-    RobustScaler,
-)
+from .preprocessing import preproc_conf
 
 
 # For comparison, this selection of operators and hyperparameters is
@@ -46,35 +35,7 @@ from sklearn.preprocessing import (
 
 clf_config = {
     "data": ["data"],
-    SuperVectorizer: {
-        "_input": "data",
-        "_output": "numeric_data",
-        'cardinality_threshold': [40],
-        'low_card_cat_transformer': {
-            OneHotEncoder: {
-                #'categories': ['auto'],
-            },
-        },
-        'high_card_cat_transformer': {
-            #OrdinalEncoder: {
-            #    'categories': ['auto'],
-            #},
-            #SimilarityEncoder: {
-            #    'n_prototypes': [10, 25, 50, 100],
-            #},
-            GapEncoder: {
-                #'analyzer': ['word', 'char', 'char_wb'],
-            },
-            #MinHashEncoder: {
-            #    'n_components': [10, 30, 50, 100],
-            #    'hashing': ['fast', 'murmur'],
-            #},
-        },
-        'numerical_transformer': {
-            #RobustScaler: {},
-            StandardScaler: {},
-        }
-    },
+    **preproc_conf,
     "alpha": [1e-3, 1e-2, 1e-1, 1.0, 10.0, 100.0],
     "fit_prior": [True, False],
     "min_samples_split": range(2, 21),

--- a/gama/configuration/classification.py
+++ b/gama/configuration/classification.py
@@ -16,8 +16,6 @@ from sklearn.preprocessing import (
     MinMaxScaler,
     Normalizer,
     PolynomialFeatures,
-    RobustScaler,
-    StandardScaler,
     Binarizer,
 )
 from sklearn.kernel_approximation import Nystroem, RBFSampler
@@ -29,10 +27,18 @@ from sklearn.feature_selection import (
     VarianceThreshold,
 )
 
-
-class SuperEncoder(StandardScaler):
-    # For testing purposes only
-    pass
+from dirty_cat import (
+    SuperVectorizer,
+    SimilarityEncoder,
+    GapEncoder,
+    MinHashEncoder,
+)
+from sklearn.preprocessing import (
+    OneHotEncoder,
+    OrdinalEncoder,
+    StandardScaler,
+    RobustScaler,
+)
 
 
 # For comparison, this selection of operators and hyperparameters is
@@ -40,11 +46,34 @@ class SuperEncoder(StandardScaler):
 
 clf_config = {
     "data": ["data"],
-    SuperEncoder: {
+    SuperVectorizer: {
         "_input": "data",
         "_output": "numeric_data",
-        "with_std": [True, False],
-        "with_mean": [True, False],
+        'cardinality_threshold': [40],
+        'low_card_cat_transformer': {
+            OneHotEncoder: {
+                #'categories': ['auto'],
+            },
+        },
+        'high_card_cat_transformer': {
+            #OrdinalEncoder: {
+            #    'categories': ['auto'],
+            #},
+            #SimilarityEncoder: {
+            #    'n_prototypes': [10, 25, 50, 100],
+            #},
+            GapEncoder: {
+                #'analyzer': ['word', 'char', 'char_wb'],
+            },
+            #MinHashEncoder: {
+            #    'n_components': [10, 30, 50, 100],
+            #    'hashing': ['fast', 'murmur'],
+            #},
+        },
+        'numerical_transformer': {
+            #RobustScaler: {},
+            StandardScaler: {},
+        }
     },
     "alpha": [1e-3, 1e-2, 1e-1, 1.0, 10.0, 100.0],
     "fit_prior": [True, False],
@@ -147,8 +176,6 @@ clf_config = {
         "interaction_only": [False],
     },
     RBFSampler: {"gamma": np.arange(0.0, 1.01, 0.05)},
-    RobustScaler: {},
-    StandardScaler: {},
     # Selectors
     SelectFwe: {"alpha": np.arange(0, 0.05, 0.001), "score_func": {f_classif: None}},
     SelectPercentile: {"percentile": range(1, 100), "score_func": {f_classif: None}},

--- a/gama/configuration/parser.py
+++ b/gama/configuration/parser.py
@@ -219,7 +219,8 @@ def remove_primitives_with_unreachable_input(
     for return_type, prims_and_terms in pset.items():
         for pt in prims_and_terms:
             if isinstance(pt, Primitive) and pt.data_input not in reachability:
-                print(pt)
+                pass
+                #print(pt)  # FIXME
     return {
         return_type: [
             pt

--- a/gama/configuration/preprocessing.py
+++ b/gama/configuration/preprocessing.py
@@ -1,0 +1,49 @@
+from dirty_cat import (
+    SuperVectorizer,
+    SimilarityEncoder,
+    GapEncoder,
+    MinHashEncoder,
+)
+from sklearn.preprocessing import (
+    OneHotEncoder,
+    OrdinalEncoder,
+    StandardScaler,
+    RobustScaler,
+)
+#sv = SuperVectorizer(impute_missing='force', cardinality_threshold=40, low_card_cat_transformer=OneHotEncoder(handle_unknown='ignore'), high_card_cat_transformer=MinHashEncoder(), numerical_transformer=StandardScaler())
+
+preproc_conf = {
+    SuperVectorizer: {
+        "_input": "data",
+        "impute_missing": ['force'],
+        'cardinality_threshold': [20, 40, 60],
+        'low_card_cat_transformer': {
+            OneHotEncoder: {
+                # 'categories': ['auto'],
+                'handle_unknown': ['ignore'],
+            },
+        },
+        'high_card_cat_transformer': {
+            OrdinalEncoder: {
+            #   'categories': ['auto'],
+                "handle_unknown": ["use_encoded_value"],
+                "unknown_value": [-1],
+                "encoded_missing_value": [-2],
+            },
+            # SimilarityEncoder: {
+            #    'n_prototypes': [10, 25, 50, 100],
+            # },
+            # GapEncoder: {
+            #     'analyzer': ['word', 'char', 'char_wb'],
+            # },
+            MinHashEncoder: {
+            #    'n_components': [10, 30, 50, 100],
+            #    'hashing': ['fast', 'murmur'],
+            },
+        },
+        'numerical_transformer': {
+            RobustScaler: {},
+            StandardScaler: {},
+        }
+    },
+}

--- a/gama/configuration/preprocessing.py
+++ b/gama/configuration/preprocessing.py
@@ -10,38 +10,37 @@ from sklearn.preprocessing import (
     StandardScaler,
     RobustScaler,
 )
-#sv = SuperVectorizer(impute_missing='force', cardinality_threshold=40, low_card_cat_transformer=OneHotEncoder(handle_unknown='ignore'), high_card_cat_transformer=MinHashEncoder(), numerical_transformer=StandardScaler())
+
 
 preproc_conf = {
     SuperVectorizer: {
         "_input": "data",
-        "impute_missing": ['force'],
-        'cardinality_threshold': [20, 40, 60],
-        'low_card_cat_transformer': {
+        "impute_missing": ["force"],
+        "cardinality_threshold": [20, 40, 60],
+        "low_card_cat_transformer": {
             OneHotEncoder: {
-                # 'categories': ['auto'],
-                'handle_unknown': ['ignore'],
+                "handle_unknown": ["ignore"],
             },
         },
-        'high_card_cat_transformer': {
+        "high_card_cat_transformer": {
             OrdinalEncoder: {
-            #   'categories': ['auto'],
+                "categories": ["auto"],
                 "handle_unknown": ["use_encoded_value"],
                 "unknown_value": [-1],
                 "encoded_missing_value": [-2],
             },
-            # SimilarityEncoder: {
-            #    'n_prototypes': [10, 25, 50, 100],
-            # },
-            # GapEncoder: {
-            #     'analyzer': ['word', 'char', 'char_wb'],
-            # },
+            SimilarityEncoder: {
+               "n_prototypes": [10, 25, 50, 100],
+            },
+            GapEncoder: {
+                "analyzer": ["word", "char", "char_wb"],
+            },
             MinHashEncoder: {
-            #    'n_components': [10, 30, 50, 100],
-            #    'hashing': ['fast', 'murmur'],
+               "n_components": [10, 30, 50, 100],
+               "hashing": ["fast", "murmur"],
             },
         },
-        'numerical_transformer': {
+        "numerical_transformer": {
             RobustScaler: {},
             StandardScaler: {},
         }

--- a/gama/configuration/regression.py
+++ b/gama/configuration/regression.py
@@ -129,8 +129,6 @@ reg_config = {
         "interaction_only": [False],
     },
     RBFSampler: {"gamma": np.arange(0.0, 1.01, 0.05)},
-    RobustScaler: {},
-    StandardScaler: {},
     # Selectors
     SelectFwe: {"alpha": np.arange(0, 0.05, 0.001), "score_func": {f_regression: None}},
     SelectPercentile: {"percentile": range(1, 100), "score_func": {f_regression: None}},

--- a/gama/configuration/regression.py
+++ b/gama/configuration/regression.py
@@ -31,11 +31,15 @@ from sklearn.tree import DecisionTreeRegressor
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.svm import LinearSVR
 
+from .preprocessing import preproc_conf
+
+
 # For comparison, this selection of operators and hyperparameters is
 # currently most of what TPOT supports.
 
 reg_config = {
-    "numeric_data": ["data"],
+    "data": ["data"],
+    **preproc_conf,
     ElasticNetCV: {
         "l1_ratio": np.arange(0.0, 1.01, 0.05),
         "tol": [1e-5, 1e-4, 1e-3, 1e-2, 1e-1],

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -513,7 +513,7 @@ class Gama(ABC):
                 x, is_classification
             )
             self._fixed_pipeline_extension = basic_pipeline_extension(
-                self._x, is_classification
+                is_classification
             )
             self._operator_set._safe_compile = partial(
                 self._operator_set._compile,

--- a/gama/gama.py
+++ b/gama/gama.py
@@ -42,7 +42,6 @@ from gama.search_methods.async_ea import AsyncEA
 from gama.utilities.generic.timekeeper import TimeKeeper
 from gama.logging.utility_functions import register_stream_log
 from gama.utilities.preprocessing import (
-    basic_encoding,
     basic_pipeline_extension,
 )
 from gama.genetic_programming.mutation import random_valid_mutation_in_place
@@ -255,7 +254,6 @@ class Gama(ABC):
 
         self._x: Optional[pd.DataFrame] = None
         self._y: Optional[pd.DataFrame] = None
-        self._basic_encoding_pipeline: Optional[Pipeline] = None
         self._fixed_pipeline_extension: List[Tuple[str, TransformerMixin]] = []
         self._inferred_dtypes: List[Type] = []
         self.model: object = None
@@ -359,8 +357,6 @@ class Gama(ABC):
     ) -> pd.DataFrame:
         if isinstance(x, np.ndarray):
             x = self._np_to_matching_dataframe(x)
-        if self._basic_encoding_pipeline:
-            x = self._basic_encoding_pipeline.transform(x)
         return x
 
     def _predict(self, x: pd.DataFrame) -> np.ndarray:
@@ -530,12 +526,9 @@ class Gama(ABC):
         with self._time_manager.start_activity(
             "preprocessing", activity_meta=["default"]
         ):
-            x, self._y = format_x_y(x, y)
+            self._x, self._y = format_x_y(x, y)
             self._inferred_dtypes = x.dtypes
             is_classification = hasattr(self, "_label_encoder")
-            self._x, self._basic_encoding_pipeline = basic_encoding(
-                x, is_classification
-            )
             self._fixed_pipeline_extension = basic_pipeline_extension(
                 is_classification
             )
@@ -688,12 +681,7 @@ class Gama(ABC):
         if raise_if_exists and file is not None and os.path.isfile(file):
             raise FileExistsError(f"File {file} already exists.")
 
-        if self._basic_encoding_pipeline is not None:
-            script_text = self._post_processing.to_code(
-                self._basic_encoding_pipeline.steps + self._fixed_pipeline_extension
-            )
-        else:
-            script_text = self._post_processing.to_code(self._fixed_pipeline_extension)
+        script_text = self._post_processing.to_code(self._fixed_pipeline_extension)
 
         if file:
             with open(file, "w") as fh:

--- a/gama/genetic_programming/compilers/scikitlearn.py
+++ b/gama/genetic_programming/compilers/scikitlearn.py
@@ -25,12 +25,23 @@ log = logging.getLogger(__name__)
 
 
 def primitive_node_to_sklearn(primitive_node: PrimitiveNode) -> object:
-    hyperparameters = {
-        terminal.output: terminal.value
-        for terminal in primitive_node._children
+    hyperparameters = {}
+    for terminal in primitive_node._children:
         # BANDAGE
-        if isinstance(terminal, Terminal) and terminal.value != "data"
-    }
+        if isinstance(terminal, Terminal) and terminal.value == "data":
+            continue
+        # Check if primitive is hyperparameter or different step in the pipeline
+        # if it is a hyperparameter it has input type dont_remove
+        if isinstance(terminal, PrimitiveNode) and terminal._primitive.data_input == "dont_remove":
+            hps = {
+                hp.output: hp.value
+                for hp in terminal._children
+            }
+            value = terminal._primitive.identifier(**hps)
+            hyperparameters.update({terminal._primitive.output: value})
+        if isinstance(terminal, Terminal):
+            value = terminal.value
+            hyperparameters.update({terminal.output: value})
     return primitive_node._primitive.identifier(**hyperparameters)
 
 

--- a/gama/genetic_programming/components/individual.py
+++ b/gama/genetic_programming/components/individual.py
@@ -63,12 +63,17 @@ class Individual:
     @property
     def primitives(self) -> List[PrimitiveNode]:
         """Lists all primitive nodes, starting with the Individual's main node."""
+
+        def is_data_primitive(child) -> bool:
+            return isinstance(child, PrimitiveNode) and child._primitive.data_input != "dont_remove"
+
         primitives = [self.main_node]
         current_children = self.main_node._children
-        while any(isinstance(child, PrimitiveNode) for child in current_children):
+        while any(is_data_primitive(child) for child in current_children):
             # Only data input can be a primitive node, so there is never more than one.
             child_node = next(
-                child for child in current_children if isinstance(child, PrimitiveNode)
+                child for child in current_children
+                if is_data_primitive(child)
             )
             primitives.append(child_node)
             current_children = child_node._children

--- a/gama/genetic_programming/components/primitive_node.py
+++ b/gama/genetic_programming/components/primitive_node.py
@@ -13,7 +13,7 @@ class PrimitiveNode:
         The Primitive type of this PrimitiveNode.
     data_node: PrimitiveNode
         The PrimitiveNode that specifies all preprocessing before this PrimitiveNode.
-    terminals: List[Union["PrimitiveNode", Terminal]]
+    children: List[Union["PrimitiveNode", Terminal]]
         A non-empty list of terminals and primitivenodes matching the `primitive` input.
     """
 
@@ -37,8 +37,8 @@ class PrimitiveNode:
         input_str = f"{self.input_node!r}" if self.input_node else ""
         terminal_str = ", ".join(
             [
-                repr(terminal)
-                for terminal in self.terminals
+                repr(terminal) if isinstance(terminal, Terminal) else str(terminal)
+                for terminal in self.terminals + self.primitives
                 if terminal != self.input_node
             ]
         )

--- a/gama/genetic_programming/crossover.py
+++ b/gama/genetic_programming/crossover.py
@@ -148,6 +148,6 @@ def _valid_crossover_functions(ind1: Individual, ind2: Individual) -> List[Calla
     crossover_choices = []
     if list(_shared_terminals(ind1, ind2)):
         crossover_choices.append(crossover_terminals)
-    if len(list(ind1.primitives)) >= 2 and len(list(ind2.primitives)) >= 2:
+    if len(list(ind1.primitives)) >= 3 and len(list(ind2.primitives)) >= 3:
         crossover_choices.append(crossover_primitives)
     return crossover_choices

--- a/gama/genetic_programming/mutation.py
+++ b/gama/genetic_programming/mutation.py
@@ -105,7 +105,10 @@ def mut_shrink(
     if shrink_by is not None and n_primitives <= shrink_by:
         raise ValueError(f"Can't shrink size {n_primitives} individual by {shrink_by}.")
     if shrink_by is None:
-        shrink_by = random.randint(1, n_primitives)
+        if n_primitives > 1:
+            shrink_by = random.randint(1, n_primitives)
+        else:
+            shrink_by = 0
 
     i = len(individual.primitives) - 1
     while shrink_by > 0 and i > 0:

--- a/gama/genetic_programming/mutation.py
+++ b/gama/genetic_programming/mutation.py
@@ -7,7 +7,7 @@ from functools import partial
 from typing import Callable, Optional, List, Dict
 
 from gama.genetic_programming.components.terminal import Terminal
-from .components import Individual
+from .components import Individual, Primitive
 from .operations import random_primitive_node
 
 
@@ -139,7 +139,16 @@ def mut_insert(individual: Individual, primitive_set: dict) -> None:
         Individual to mutate in-place.
     primitive_set: dict
     """
-    parent_node = random.choice(list(individual.primitives))
+    candidate_primitives = [
+        primitive for primitive in individual.primitives
+        if any(
+            isinstance(p, Primitive)
+            for p in primitive_set[primitive._primitive.data_input]
+        )
+    ]
+    if not candidate_primitives:
+        raise Exception(f'No candidate primitives')
+    parent_node = random.choice(candidate_primitives)
     new_primitive_node = random_primitive_node(
         output_type=parent_node._primitive.data_input,
         primitive_set=primitive_set,

--- a/gama/genetic_programming/operations.py
+++ b/gama/genetic_programming/operations.py
@@ -9,6 +9,8 @@ from gama.genetic_programming.components import (
     DATA_TERMINAL,
 )
 
+from dirty_cat import SuperVectorizer
+
 
 def random_terminals_for_primitive(
     primitive_set: dict, primitive: Primitive
@@ -85,6 +87,11 @@ def random_primitive_node(
     data_input_type: Optional[str] = None,
 ) -> PrimitiveNode:
     """Create a PrimitiveNode with specified output_type and random terminals."""
+    # Hotfix
+    #  otherwise, the function tries to replace the SuperVectorizer
+    #  with something else (except none match).
+    if isinstance(exclude, Primitive) and exclude.identifier is SuperVectorizer:
+        exclude = None
     candidates = [
         p
         for p in primitive_set[output_type]
@@ -102,6 +109,8 @@ def random_primitive_node(
                 c for c in candidates if reachability[c.data_input] == with_depth - 1
             ]
 
+    if len(candidates) == 0:
+        raise Exception('No candidates to chose from')
     primitive = random.choice(candidates)
     remaining_depth = with_depth - 1 if with_depth else None
     children = random_children_for_primitive(

--- a/gama/genetic_programming/operations.py
+++ b/gama/genetic_programming/operations.py
@@ -89,7 +89,7 @@ def random_primitive_node(
     """Create a PrimitiveNode with specified output_type and random terminals."""
     # Hotfix
     #  otherwise, the function tries to replace the SuperVectorizer
-    #  with something else (except none match).
+    #  with something else (but none match).
     if isinstance(exclude, Primitive) and exclude.identifier is SuperVectorizer:
         exclude = None
     candidates = [

--- a/gama/genetic_programming/operator_set.py
+++ b/gama/genetic_programming/operator_set.py
@@ -52,10 +52,12 @@ class OperatorSet:
             log.warning(f"Error raised during evaluation: {str(future.exception)}.")
         return future
 
-    def try_until_new(self, operator, *args, **kwargs):
+    def try_until_new(self, operator: Callable[..., Individual], *args, **kwargs):
         """Keep executing `operator` until a new individual is created."""
         for _ in range(self._max_retry):
             individual = operator(*args, **kwargs)
+            if str(individual.main_node) == 'SuperVectorizer':
+                return individual
             if str(individual.main_node) not in self._completed_evaluations:
                 return individual
         else:

--- a/gama/postprocessing/best_fit.py
+++ b/gama/postprocessing/best_fit.py
@@ -23,6 +23,8 @@ class BestFitPostProcessing(BasePostProcessing):
     def post_process(
         self, x: pd.DataFrame, y: pd.Series, timeout: float, selection: List[Individual]
     ) -> object:
+        if len(selection) == 0:
+            raise Exception('No individual to choose from')
         self._selected_individual = selection[0]
         return self._selected_individual.pipeline.fit(x, y)
 

--- a/gama/utilities/preprocessing.py
+++ b/gama/utilities/preprocessing.py
@@ -1,10 +1,7 @@
 import logging
-from typing import Optional, Iterator, List, Tuple
-import category_encoders as ce
 import pandas as pd
+from typing import Optional, Iterator, List, Tuple
 from sklearn.base import TransformerMixin
-from sklearn.impute import SimpleImputer
-from dirty_cat import SuperVectorizer
 
 log = logging.getLogger(__name__)
 
@@ -42,36 +39,10 @@ def select_categorical_columns(
                 yield column
 
 
-def basic_encoding(
-    x: pd.DataFrame, is_classification: bool
-) -> Tuple[pd.DataFrame, TransformerMixin]:
-    """Perform 'basic' encoding of categorical features.
-
-    Specifically, perform:
-     - Ordinal encoding for features with 2 or fewer unique values.
-       FIXME: feature of dirty_cat 0.3 (which is not out as of August 2022)
-     - One hot encoding for features with at most 10 unique values.
-     - Ordinal encoding for features with 11+ unique values, if y is categorical.
-    """
-    ohe = ce.OneHotEncoder(handle_missing="value")
-    ord_enc = ce.OrdinalEncoder(drop_invariant=True)
-
-    sv = SuperVectorizer(
-        cardinality_threshold=11,
-        low_card_cat_transformer=ohe,
-        high_card_cat_transformer=ord_enc if is_classification else ohe,
-    )
-    x_enc = pd.DataFrame(sv.fit_transform(x))
-    return x_enc, sv
-
-
 def basic_pipeline_extension(
     is_classification: bool
 ) -> List[Tuple[str, TransformerMixin]]:
-    """Define a TargetEncoder and SimpleImputer.
-
-    TargetEncoding is will encode categorical features with more than 10 unique values,
-    if y is not categorical. SimpleImputer imputes with the median.
     """
-    # These steps need to be in the pipeline because they need to be trained each fold.
-    return [("imputation", SimpleImputer(strategy="median"))]
+    TODO: remove altogether
+    """
+    return []

--- a/gama/utilities/preprocessing.py
+++ b/gama/utilities/preprocessing.py
@@ -4,7 +4,6 @@ import category_encoders as ce
 import pandas as pd
 from sklearn.base import TransformerMixin
 from sklearn.impute import SimpleImputer
-from sklearn.pipeline import Pipeline
 from dirty_cat import SuperVectorizer
 
 log = logging.getLogger(__name__)
@@ -62,12 +61,12 @@ def basic_encoding(
         low_card_cat_transformer=ohe,
         high_card_cat_transformer=ord_enc if is_classification else ohe,
     )
-    x_enc = sv.fit_transform(x)
+    x_enc = pd.DataFrame(sv.fit_transform(x))
     return x_enc, sv
 
 
 def basic_pipeline_extension(
-    x: pd.DataFrame, is_classification: bool
+    is_classification: bool
 ) -> List[Tuple[str, TransformerMixin]]:
     """Define a TargetEncoder and SimpleImputer.
 
@@ -75,13 +74,4 @@ def basic_pipeline_extension(
     if y is not categorical. SimpleImputer imputes with the median.
     """
     # These steps need to be in the pipeline because they need to be trained each fold.
-    extension_steps = []
-    if not is_classification:
-        # TargetEncoder is broken with categorical target
-        many_factor_features = list(select_categorical_columns(x, min_f=11))
-        extension_steps.append(
-            ("target_enc", ce.TargetEncoder(cols=many_factor_features))
-        )
-    extension_steps.append(("imputation", SimpleImputer(strategy="median")))
-
-    return extension_steps
+    return [("imputation", SimpleImputer(strategy="median"))]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "category-encoders>=1.2.8",
   "black==19.10b0",
   "psutil",
+  "dirty_cat>=0.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR aims at implementing [dirty_cat](https://github.com/dirty-cat/dirty_cat)'s encoders (currently [SimilarityEncoder](https://dirty-cat.github.io/stable/generated/dirty_cat.SimilarityEncoder.html), [GapEncoder](https://dirty-cat.github.io/stable/generated/dirty_cat.GapEncoder.html) and [MinHashEncoder](https://dirty-cat.github.io/stable/generated/dirty_cat.MinHashEncoder.html)) to GAMA's search space via the use of the [SuperVectorizer](https://dirty-cat.github.io/stable/generated/dirty_cat.SuperVectorizer.html).

The point of adding the dirty_cat encoders is for GAMA to be able to handle dirty categorical features in tabular data.

Using the SuperVectorizer gives a simplified interface to the sklearn's ColumnTransformer, and allows to mix & match different encoding techniques.

For the content of this PR to run, the features implemented in dirty_cat 0.3 are required. However, at the time of writing these lines (August 2022), this version is not out yet.

TODO:
- [x] wait for dirty_cat 0.3 to be out
- [ ] fine-tune the preprocessing search space
- [ ] benchmark GAMA to compare the performance before and after the introduction of the SuperVectorizer